### PR TITLE
完成继承的练习题

### DIFF
--- a/lib/base.es5.js
+++ b/lib/base.es5.js
@@ -1,4 +1,36 @@
-function Base() {}
-Base.extend = function () {}
+function Base() {
+  this.events = [];
+}
+Base.extend = function () {
+  var _this = this;
+  var args = Array.prototype.slice.apply(arguments);
+  var extend = function(){
+    // 构造继承
+    _this.call(this);
+  };
+  // 原型链继承
+  extend.prototype = new _this();
+
+  args.forEach(function (obj) {
+    if(Object.prototype.toString.call(obj) === '[object Object]') {
+      for(var key in obj) {
+        extend.prototype[key] = obj[key];
+        extend[key] = obj[key];
+      }
+    }
+  });
+
+  extend.extend = _this.extend;
+
+  return extend;
+}
+
+Base.prototype.on = function (name, fn) {
+  this.events[name] = fn;
+}
+
+Base.prototype.trigger = function (name, value) {
+  this.events[name] && this.events[name].call(this, value);
+}
 
 module.exports = Base

--- a/lib/base.es6.js
+++ b/lib/base.es6.js
@@ -1,3 +1,13 @@
-class Base {}
+class Base {
+  constructor(options){
+    this.events = [];
+  }
+  on(name, fn) {
+    this.events[name] = fn;
+  }
+  trigger(name, value){
+    this.events[name] && this.events[name].call(this, value);
+  }
+}
 
 module.exports = Base

--- a/test/test.js
+++ b/test/test.js
@@ -50,7 +50,7 @@ describe('实现一个基类，可以继承，可以监听事件', function () {
           return word
         }
       })
-      var myclass = new MyClass
+      var myclass = new MyClass;
       assert.equal(myclass.getVal(), 'hello world')
       assert.equal(MyClass.say('haha'), 'haha')
       assert.equal(myclass instanceof MyClass, true)


### PR DESCRIPTION
这个ES5的练习，真是让我疏通了很多以往混淆的知识点。
以前并不明白构造继承和原型链上的继承。
1、构造继承
var child = function(){
   Parent.call(this)
}
执行 Parent 的 construtor 方法，并将 this 是指向 child 。
缺点：无法具有 Parent 原型上的属性和方法。
2、原型继承
child.prototype = new Parent()
将 child 的 prototype 指向 Parent的原型, 让 child 具有 Parent原型上的属性和方法。
缺点：Parent可能会在construtor 方法里对构造函数的属性做初始化和赋值，如果Parent原型上的方法有对一些构造函数的属性进行读取/修改，将可能存在预期之外的结果。
3、组合继承
var child = function(){
   Parent.call(this)
}
child.prototype = new Parent();
刚好就是1和2的互补。